### PR TITLE
Handle smart apostrophe in slug.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -364,7 +364,7 @@ var slug = exports.slug = function(str, sep) {
 	var esc = escapeRegExp(sep);
 	str = stripDiacritics(str);
 	str = transliterate(str);
-	return str.replace(/['"()\.]/g, '').replace(/[^a-z0-9_\-]+/gi, sep).replace(new RegExp(esc + '+', 'g'), sep).replace(new RegExp('^' + esc + '+|' + esc + '+$'), '').toLowerCase();
+	return str.replace(/['’"()\.]/g, '').replace(/[^a-z0-9_\-]+/gi, sep).replace(new RegExp(esc + '+', 'g'), sep).replace(new RegExp('^' + esc + '+|' + esc + '+$'), '').toLowerCase();
 }
 
 

--- a/tests/strings.js
+++ b/tests/strings.js
@@ -147,4 +147,10 @@ describe('String transform', function(){
 			demand(utils.slug('Как упоительны в России вечера!')).to.equal('kak-upoytelny-v-rossyy-vechera');
 		});
 	});
+
+	describe('Smart apostrophe', function() {
+		it('should transform "The User’s Guide" to "the-users-guide"', function() {
+			demand(utils.slug('The User’s Guide')).to.equal('the-users-guide');
+		});
+	});
 });


### PR DESCRIPTION
I was going to add in the other "smart" quotes as well but realised they're always next to whitespace and so get transformed to "--" and then the double is replaced with a single "-".
