### PR TITLE
update limax and slug without tone number in pinyin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -367,7 +367,7 @@ var slug = exports.slug = function(str, sep, options) {
 	sep = sep || '-';
 
 	var limax = require("limax");
-	return limax(str, {lang: options["locale"], separator: sep});
+	return limax(str, {tone: false, lang: options["locale"], separator: sep});
 }
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "underscore": "~1.7.0",
     "html-stringify": "~0.0.2",
     "i": "~0.3.2",
-    "limax": "~1.0.1"
+    "limax": "~1.1.0"
   },
   "devDependencies": {
     "mocha": ">= 1.19 < 2",


### PR DESCRIPTION
Fix the tone numbers problem in https://github.com/lovell/limax/issues/4#event-317042267