### PR TITLE
option-simple: Simplified the options method.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,14 +154,12 @@ var isEmail = exports.isEmail = function isEmail (str) {
  */
 
 var options = exports.options = function options (defaults, ops) {
-	if (!ops) ops = {};
-	if (!defaults) return ops;
-	Object.keys(defaults).forEach(function (key) {
-		if (!(key in ops)) {
-			ops[key] = defaults[key];
-		}
+	defaults = defaults || {};
+	ops = ops || {};
+	Object.keys(ops).forEach(function(key) {
+		defaults[key] = ops[key];
 	});
-	return ops;
+	return defaults;
 };
 
 /**

--- a/tests/options.js
+++ b/tests/options.js
@@ -7,10 +7,16 @@ describe('Options', function () {
 	it('should return an empty object my default', function () {
 		demand(utils.options()).to.eql({});
 	});
-	it('should default missing options', function () {
+	
+	it('should add missing options', function () {
 		demand(utils.options({ a: 'a' }, { b: 'b' })).to.eql({ a: 'a', b: 'b' });
 	});
-	it('should preserve existing options', function () {
+	
+	it('should override existing options', function () {
 		demand(utils.options({ a: 'b' }, { a: 'a', b: 'b' })).to.eql({ a: 'a', b: 'b' });
+	});
+
+	it('should preserve option missing in the extendWith options object', function() {
+		demand(utils.options({ a: 'b' , c: 'c' }, { a: 'a', b: 'b' })).to.eql({ a: 'a', b: 'b', c :'c' });
 	});
 });


### PR DESCRIPTION
## Changes

Changes made ensures that the intention behind utils.option augments the first parameter sent in.

1. Simplied the options method. `option` parameter is to augment the `defaults`, previous implementation intended to do the other way around.
2. Test updated to ensure that missing key in the `option` wouldn't lead to a missing key in the returned object.