### PR TITLE
Remove underscore

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,6 @@
 // HTML Entity encode / decode is based on code in node-html-to-text
 // see https://github.com/werk85/node-html-to-text
 
-var _ = require('underscore');
 var _slug = require('slug');
 var inflect = require('i')();
 
@@ -40,6 +39,17 @@ var transliteration = require('./transliteration.cyr');
 // Constants for distance calculation
 var RADIUS_KM = 6371;
 var RADIUS_MILES = 3959;
+
+function compact(arr) {
+	return arr.filter(function(v) {
+		return !!v;
+	});
+}
+
+function deepClone(obj) {
+	obj = obj || {};
+	return JSON.parse(JSON.stringify(obj));
+}
 
 /**
  * Determines if `arg` is a function.
@@ -181,7 +191,7 @@ var optionsMap = exports.optionsMap = function optionsMap (arr, property, clone)
 	for (var i = 0; i < arr.length; i++) {
 		var prop = (property) ? arr[i][property] : arr[i];
 		if (clone) {
-			prop = _.clone(prop);
+			prop = deepClone(prop);
 		}
 		obj[arr[i].value] = prop;
 	}
@@ -363,7 +373,7 @@ var plural = exports.plural = function plural (count, sn, pl) {
 	if (typeof count === 'string') {
 		count = Number(count);
 	} else if (typeof count !== 'number') {
-		count = _.size(count);
+		count = Object.keys(count).length;
 	}
 	return (count === 1 ? sn : pl).replace('*', count);
 };
@@ -414,7 +424,7 @@ var titlecase = exports.titlecase = function titlecase (str) {
 			parts[i] = upcase(parts[i]);
 		}
 	}
-	return _.compact(parts).join(' ');
+	return compact(parts).join(' ');
 };
 
 /**
@@ -599,7 +609,7 @@ var keyToLabel = exports.keyToLabel = function keyToLabel (str) {
 			parts[i] = upcase(parts[i]);
 		}
 	}
-	return _.compact(parts).join(' ');
+	return compact(parts).join(' ');
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -154,14 +154,12 @@ var isEmail = exports.isEmail = function isEmail (str) {
  */
 
 var options = exports.options = function options (defaults, ops) {
-	if (!ops) ops = {};
-	if (!defaults) return ops;
-	Object.keys(defaults).forEach(function (key) {
-		if (!(key in ops)) {
-			ops[key] = defaults[key];
-		}
+	defaults = defaults || {};
+	ops = ops || {};
+	Object.keys(ops).forEach(function(key) {
+		defaults[key] = ops[key];
 	});
-	return ops;
+	return defaults;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "html-stringify": "~0.0.3",
     "i": "~0.3.3",
     "slug": "^0.9.1",
-    "randomkey": "^1.0.0",
-    "underscore": "~1.8.3"
+    "randomkey": "^1.0.0"
   },
   "devDependencies": {
     "happiness": "^1.0.7",

--- a/tests/options.js
+++ b/tests/options.js
@@ -7,10 +7,16 @@ describe('Options', function () {
 	it('should return an empty object my default', function () {
 		demand(utils.options()).to.eql({});
 	});
-	it('should default missing options', function () {
+	
+	it('should add missing options', function () {
 		demand(utils.options({ a: 'a' }, { b: 'b' })).to.eql({ a: 'a', b: 'b' });
 	});
-	it('should preserve existing options', function () {
+	
+	it('should override existing options', function () {
 		demand(utils.options({ a: 'b' }, { a: 'a', b: 'b' })).to.eql({ a: 'a', b: 'b' });
+	});
+
+	it('should preserve option missing in the extendWith options object', function() {
+		demand(utils.options({ a: 'b' , c: 'c' }, { a: 'a', b: 'b' })).to.eql({ a: 'a', b: 'b', c :'c' });
 	});
 });


### PR DESCRIPTION
## Changes

- Simplified options method to express its intention. Instead of mutating `ops` object, we augment the `defaults` object with keys from `ops`. (test updated with new case)
- Removed underscore dependency from the code. This is mostly because it is rarely used and `clone` method just preforms a shallow copy of the object where as the keys that are object are only stored as reference.

I just realised that I need to remove underscore from `package.json` as well.