### PR TITLE
Implemented noop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -699,3 +699,8 @@ exports.kmBetween = function kmBetween (point1, point2) {
 exports.kmBetween = function milesBetween (point1, point2) {
 	return calculateDistance(point1, point2) * RADIUS_MILES;
 };
+
+/**
+ * No operation
+ */
+exports.noop = function() {};


### PR DESCRIPTION
There are times I found the following repeatedly in __keystone__

```
callback = callback || function() {};
```

---

Implementing [noop](https://en.wikipedia.org/wiki/NOP) ensures consistency in writing code and it is much faster to read, rather than creating a new _anonymous_ every time.

finer usage:

__old__
```
callBatman(callback) {
  callback = callback || noop;
  // code
}
```

__new__
```
callBatman(callback = noop) {
  // code
}
```