### PR TITLE
Added new functional utility to check for base64 strings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,6 +162,11 @@ var isEmail = exports.isEmail = function isEmail (str) {
  * @return {Object} the options argument merged with defaults
  * @api public
  */
+var isDataURL = exports.isDataURL = function isDataURL (str) {
+	if (typeof str !== 'string') return false;
+	var isDataURLRegex = /^\s*data:([a-z]+\/[a-z0-9\-\+]+(;[a-z\-]+\=[a-z0-9\-]+)?)?(;base64)?,[a-z0-9\!\$\&\'\,\(\)\*\+\,\;\=\-\.\_\~\:\@\/\?\%\s]*\s*$/i;
+	return !!str.match(isDataURLRegex);
+};
 
 var options = exports.options = function options (defaults, ops) {
 	defaults = defaults || {};

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -1,0 +1,19 @@
+var demand = require('must');
+var utils = require('../index');
+
+describe('Functional', function () {
+  describe('isDataURL', function () {
+		it('Should return true for a valid data URL', function () {
+      var dataString = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFCAYAAACN//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==';
+			demand(utils.isDataURL(dataString)).to.equal(true);
+		});
+		it('Should return false for an invalid data URL', function () {
+      var dataString = 'JRU5ErkJggg';
+			demand(utils.isDataURL(dataString)).to.equal(false);
+		});
+		it('Should return false for non-string inputs', function () {
+      var dataString = 1;
+			demand(utils.isDataURL(dataString)).to.equal(false);
+		});
+	});
+});


### PR DESCRIPTION
CHANGES:
- `isDataURL` returns a boolean if the input string is a base64 encoded string. This is mostly required
to check if an image is properly encoded. Data interaction with Canvas in browsers will generate a base64 string
of the a given image.
- This function is a pre-requisite to the work on being done on Keystone to add image editing capabilities to core for `Image` field types.
- Tests added for true, false and non-conforming inputs.

Signed-off-by: Riyadh Al Nur <riyadhalnur@verticalaxisbd.com>