### PR TITLE
Switch to speakingurl for slugifying

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0 /
+
+* fixed; switched slug dependency to `speakingurl` for Node.js v0.10+ support and full feature parity with `slug`
+
 ## v0.3.5 / 2016-05-06
 
 * fixed; switched slug dependency to `mollusc` (fork of `slug`) for Node.js v6+ support

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@
 // HTML Entity encode / decode is based on code in node-html-to-text
 // see https://github.com/werk85/node-html-to-text
 
-var _slug = require('mollusc');
+var _slug = require('speakingurl');
 var inflect = require('i')();
 
 var limax;
@@ -361,7 +361,12 @@ var transliterate = exports.transliterate = function transliterate (str) {
 
 var slug = exports.slug = function slug (str, sep, options) {
 	if (!limax) {
-		return _slug(str,sep).toLowerCase();
+		return _slug(str, {
+			separator: sep,
+			custom: {
+				'’': ''
+			}
+		}).toLowerCase();
 	}
 	options = options || {};
 	sep = sep || '-';

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "html-stringify": "^0.0.3",
     "i": "^0.3.5",
-    "mollusc": "^1.0.3",
-    "randomkey": "^1.0.0"
+    "randomkey": "^1.0.0",
+    "speakingurl": "^9.0.0"
   },
   "devDependencies": {
     "happiness": "^6.0.7",

--- a/tests/strings.js
+++ b/tests/strings.js
@@ -138,7 +138,7 @@ describe('String transform', function () {
 			demand(utils.slug('Балы, красавицы, лакеи, юнкера')).to.equal('baly-krasavicy-lakei-yunkera');
 		});
 		it('should transform "И вальсы Шуберта и хруст французской булки," to "i-valsy-shuberta-i-hrust-francuzskoj-bulki"', function () {
-			demand(utils.slug('И вальсы Шуберта и хруст французской булки,')).to.equal('i-valsy-shuberta-i-hrust-francuzskoj-bulki');
+			demand(utils.slug('И вальсы Шуберта и хруст французской булки,')).to.equal('i-valsy-shuberta-i-khrust-francuzskoi-bulki');
 		});
 		it('should transform "Любовь, шампанское, закаты, переулки" to "lyubov-shampanskoe-zakaty-pereulki"', function () {
 			demand(utils.slug('Любовь, шампанское, закаты, переулки')).to.equal('lyubov-shampanskoe-zakaty-pereulki');


### PR DESCRIPTION
The switch to `mollusc` broke quite a few tests in keystone proper. This should fix them! (major version release)